### PR TITLE
Update fabric to the latest stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ asm = "5.2"
 
 # fabric
 fabric-loader = "0.18.2"
-fabric-api = "0.139.5+1.21.11"
+fabric-api = "0.140.2+1.21.11"
 
 # neoforge
 neoforge-version = "21.11.6-beta"


### PR DESCRIPTION
- Bump version of fabric from `0.139.5+1.21.11` to `0.140.2+1.21.11`